### PR TITLE
Preserve the zoom and centerpoint when switching between boards

### DIFF
--- a/public/js/classes/Board.js
+++ b/public/js/classes/Board.js
@@ -1,6 +1,6 @@
-export default function Board(pathsData, image) {
+export default function Board(pathsData, image, zoom) {
   this.pathsData = pathsData;
   this.image = image;
-  this.zoom = null;
+  this.zoom = zoom;
   this.centerView = null;
 }

--- a/public/js/classes/Whiteboard.js
+++ b/public/js/classes/Whiteboard.js
@@ -62,6 +62,10 @@ export default class Whiteboard {
     window.app.paintBackgroundWhite();
   }
 
+  setZoom(point) {
+    window.app.setZoom(point);
+  }
+
   onMouseDown() {
     clearInterval(this.updateFrameInterval);
     this.pushToUndoStack();
@@ -158,8 +162,8 @@ export default class Whiteboard {
     window.app.setBackground(img.src);
   }
 
-  makeNewBoard() {
-    return new Board(window.app.saveProject(), this.getImage());
+  makeNewBoard(zoom = null) {
+    return new Board(window.app.saveProject(), this.getImage(), zoom);
   }
 
   pushToUndoStack() {

--- a/public/js/manager/managerBoards.js
+++ b/public/js/manager/managerBoards.js
@@ -31,9 +31,9 @@ export function updateBoardsBadge() {
   });
 }
 
-export function deactivateCurrentBoard(whiteboard) {
+export function deactivateCurrentBoard(whiteboard, zoom = null) {
   // console.log(whiteboard.getSvgImage());
-  whiteboard.boards[whiteboard.currentBoard] = whiteboard.makeNewBoard();
+  whiteboard.boards[whiteboard.currentBoard] = whiteboard.makeNewBoard(zoom);
   const currentBoardDiv = $('[data-page=page]').eq(`${whiteboard.currentBoard}`);
   currentBoardDiv.find('img').attr('src', whiteboard.boards[whiteboard.currentBoard].image);
   currentBoardDiv.find('img').show();
@@ -52,6 +52,9 @@ export function activateCurrentBoard(socket, whiteboard, stream, clickedBoardInd
   newBoardImg.setAttribute('src', whiteboard.boards[clickedBoardIndex].image);
   const newBoardPath = whiteboard.boards[clickedBoardIndex].pathsData;
   setTimeout(() => {
+    if (whiteboard.boards[whiteboard.currentBoard].zoom) {
+      whiteboard.setZoom(whiteboard.boards[whiteboard.currentBoard].zoom)
+    }
     whiteboard.setPaths(newBoardPath);
     socket.emit('currentBoardToAll', newBoardImg.getAttribute('src'));
   }, 0);
@@ -59,7 +62,9 @@ export function activateCurrentBoard(socket, whiteboard, stream, clickedBoardInd
 
 export function createNonActiveBoardElem(socket, whiteboard, board, isActive, stream) {
   function onClickNonActiveBoardElem() {
-    deactivateCurrentBoard(whiteboard);
+    const zoom = whiteboard.getZoom();
+    whiteboard.boards[whiteboard.currentBoard].zoom = zoom;
+    deactivateCurrentBoard(whiteboard, zoom);
     const clickedBoardIndex = $(this).index();
     activateCurrentBoard(socket, whiteboard, stream, clickedBoardIndex);
   }

--- a/public/js/manager/paperTools.js
+++ b/public/js/manager/paperTools.js
@@ -327,4 +327,11 @@ window.app = {
   addImg: function (imgSrc) {
     displayImage(imgSrc);
   },
+  setZoom: function (point) {
+    view.center = {
+      x: point.centerX,
+      y: point.centerY
+    }
+    view.zoom = point.zoom
+  }
 };


### PR DESCRIPTION
**Purpose of this PR**
The purpose of this ticket is to preserve the zoom and center point values while switching between boards. If the host zoomed in to a specific board, the value will be preserved so that the board will return to that zoom when they go back to that board.
**How to test**
1. Create a lecture
2. Create a few boards, and zoom in/out for a few of them
3. When you switch between the boards, you should be returned back to the same view you had before you left that board